### PR TITLE
Feat: 마이페이지 내 정보 페이지 및 기능 구현

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,6 +12,16 @@ if (
 const nextConfig: NextConfig = {
   pageExtensions,
   reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'sprint-fe-project.s3.ap-northeast-2.amazonaws.com',
+        port: '',
+        pathname: '/**',
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/(app)/mypage/info/page.tsx
+++ b/src/app/(app)/mypage/info/page.tsx
@@ -35,6 +35,10 @@ export default function MyInfoPage() {
 
   return (
     <div>
+      <h1 className='font-size-18 font-bold text-neutral-900'>내 정보</h1>
+      <p className='text-neutral-900'>
+        이미지와 닉네임, 비밀번호를 수정할 수 있습니다.
+      </p>
       <EditableAvatar
         initialImageUrl={user?.profileImageUrl || ''}
         onImageChange={handleImageChange}

--- a/src/app/(app)/mypage/info/page.tsx
+++ b/src/app/(app)/mypage/info/page.tsx
@@ -36,7 +36,7 @@ export default function MyInfoPage() {
   return (
     <div>
       <h1 className='font-size-18 font-bold text-neutral-900'>내 정보</h1>
-      <p className='text-neutral-900'>
+      <p className='font-size-16 text-neutral-700'>
         이미지와 닉네임, 비밀번호를 수정할 수 있습니다.
       </p>
       <EditableAvatar

--- a/src/app/(app)/mypage/info/page.tsx
+++ b/src/app/(app)/mypage/info/page.tsx
@@ -1,12 +1,46 @@
-import EditableAvatar from '@/domain/User/components/ui/EditableAvatar';
+'use client';
 
+import { useEffect, useState } from 'react';
+
+import EditUserInfoForm from '@/domain/User/components/form/EditUserInfoForm';
+import EditableAvatar from '@/domain/User/components/ui/EditableAvatar';
+import { useRoamReadyStore } from '@/shared/store';
+
+/**
+ * 사용자 정보 수정 페이지 컴포넌트
+ *
+ * 프로필 이미지 수정과 사용자 정보(닉네임, 비밀번호) 수정 기능을 제공합니다.
+ * EditableAvatar와 EditUserInfoForm 컴포넌트 간의 프로필 이미지 상태를 동기화합니다.
+ */
 export default function MyInfoPage() {
+  const { user } = useRoamReadyStore();
+  const [profileImageUrl, setProfileImageUrl] = useState<string>(
+    user?.profileImageUrl || '',
+  );
+
+  // user 상태가 변경될 때 프로필 이미지 URL 동기화
+  useEffect(() => {
+    if (user) {
+      setProfileImageUrl(user.profileImageUrl || '');
+    }
+  }, [user?.profileImageUrl]);
+
+  /**
+   * 아바타 이미지 변경 시 호출되는 핸들러
+   * EditableAvatar에서 이미지가 변경될 때 상태를 동기화합니다.
+   */
+  const handleImageChange = (imageUrl: string) => {
+    setProfileImageUrl(imageUrl);
+  };
+
   return (
     <div>
       <EditableAvatar
-        initialImageUrl=''
+        initialImageUrl={user?.profileImageUrl || ''}
+        onImageChange={handleImageChange}
         className='tablet:py-16 desktop:py-24 mx-auto py-24'
       />
+      <EditUserInfoForm currentProfileImageUrl={profileImageUrl} />
     </div>
   );
 }

--- a/src/app/(app)/mypage/info/page.tsx
+++ b/src/app/(app)/mypage/info/page.tsx
@@ -14,14 +14,14 @@ import { useRoamReadyStore } from '@/shared/store';
  */
 export default function MyInfoPage() {
   const { user } = useRoamReadyStore();
-  const [profileImageUrl, setProfileImageUrl] = useState<string>(
-    user?.profileImageUrl || '',
+  const [profileImageUrl, setProfileImageUrl] = useState<string | null>(
+    user?.profileImageUrl || null,
   );
 
   // user 상태가 변경될 때 프로필 이미지 URL 동기화
   useEffect(() => {
     if (user) {
-      setProfileImageUrl(user.profileImageUrl || '');
+      setProfileImageUrl(user.profileImageUrl);
     }
   }, [user?.profileImageUrl]);
 
@@ -40,7 +40,7 @@ export default function MyInfoPage() {
         onImageChange={handleImageChange}
         className='tablet:py-16 desktop:py-24 mx-auto py-24'
       />
-      <EditUserInfoForm currentProfileImageUrl={profileImageUrl} />
+      <EditUserInfoForm currentProfileImageUrl={profileImageUrl || ''} />
     </div>
   );
 }

--- a/src/domain/User/components/form/EditUserInfoForm.tsx
+++ b/src/domain/User/components/form/EditUserInfoForm.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useEffect } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+
+import EditUserInfoFormField from '@/domain/User/components/form/EditUserInfoFormField';
+import { useUserInfoMutation } from '@/domain/User/hooks/useUserInfoMutation';
+import {
+  userInfoFormSchema,
+  UserInfoFormValues,
+} from '@/domain/User/schemas/userInfoForm';
+import Button from '@/shared/components/Button';
+import { useRoamReadyStore } from '@/shared/store';
+
+interface EditUserInfoFormProps {
+  /**
+   * 현재 선택된 프로필 이미지 URL
+   * EditableAvatar에서 변경된 이미지 URL이 포함됩니다.
+   */
+  currentProfileImageUrl: string;
+}
+
+export default function EditUserInfoForm({
+  currentProfileImageUrl,
+}: EditUserInfoFormProps) {
+  const { user } = useRoamReadyStore();
+  const { mutate: updateUserInfo, isPending } = useUserInfoMutation(
+    currentProfileImageUrl,
+  );
+
+  const methods = useForm<UserInfoFormValues>({
+    resolver: zodResolver(userInfoFormSchema),
+    defaultValues: {
+      nickname: '',
+      email: '',
+      password: '',
+      passwordConfirm: '',
+    },
+  });
+
+  // 유저 정보가 로드된 후 폼 필드에 자동 입력
+  useEffect(() => {
+    if (user) {
+      methods.reset({
+        nickname: user.nickname ?? '',
+        email: user.email ?? '',
+        password: '',
+        passwordConfirm: '',
+      });
+    }
+  }, [user, methods]);
+
+  /**
+   * 폼 제출 시 호출되는 핸들러
+   * 유효성 검사를 통과한 폼 데이터를 서버로 전송합니다.
+   */
+  const onSubmit = (data: UserInfoFormValues) => {
+    if (!user) return;
+    updateUserInfo(data);
+  };
+
+  return (
+    <FormProvider {...methods}>
+      <form
+        onSubmit={methods.handleSubmit(onSubmit)}
+        className='flex flex-col gap-4'
+      >
+        <EditUserInfoFormField name='nickname' label='닉네임' type='text' />
+        <EditUserInfoFormField
+          name='email'
+          label='이메일'
+          type='email'
+          disabled
+        />
+        <EditUserInfoFormField
+          name='password'
+          label='비밀번호'
+          type='password'
+        />
+        <EditUserInfoFormField
+          name='passwordConfirm'
+          label='비밀번호 확인'
+          type='password'
+        />
+        <Button
+          type='submit'
+          variant='primary'
+          size='large'
+          disabled={isPending}
+          className='font-size-14 mt-40 rounded-3xl py-12 font-semibold disabled:bg-neutral-400 disabled:text-neutral-200'
+        >
+          {isPending ? '수정 중...' : '회원정보 수정'}
+        </Button>
+      </form>
+    </FormProvider>
+  );
+}

--- a/src/domain/User/components/form/EditUserInfoFormField.tsx
+++ b/src/domain/User/components/form/EditUserInfoFormField.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useFormContext } from 'react-hook-form';
+
+import Input from '@/shared/components/ui/input';
+import { cn } from '@/shared/libs/cn';
+
+interface EditUserInfoFormFieldProps {
+  /** 폼 필드의 name 속성 */
+  name: string;
+  /** 필드에 표시될 라벨 텍스트 */
+  label: string;
+  /** 입력 필드의 타입 */
+  type: 'text' | 'email' | 'password';
+  /** 필드 비활성화 여부 */
+  disabled?: boolean;
+}
+
+/**
+ * 사용자 정보 수정 폼에서 사용되는 개별 입력 필드 컴포넌트
+ *
+ * react-hook-form과 통합되어 있으며, 공통 Input 컴포넌트를 래핑하여
+ * 일관된 스타일과 유효성 검사 기능을 제공합니다.
+ */
+export default function EditUserInfoFormField({
+  name,
+  label,
+  type,
+  disabled,
+}: EditUserInfoFormFieldProps) {
+  const { register } = useFormContext();
+
+  return (
+    <Input.Root name={name} type={type} disabled={disabled}>
+      <div className='mt-12 flex items-center justify-between'>
+        <Input.Label className='ml-4 font-semibold text-neutral-900'>
+          {label}
+        </Input.Label>
+        <Input.Helper />
+      </div>
+      <Input.Field
+        {...register(name)}
+        className={cn(
+          'rounded-3xl border-neutral-200 p-14 py-12 text-neutral-900 placeholder:text-neutral-400',
+          disabled && 'cursor-not-allowed bg-neutral-100 text-neutral-400',
+        )}
+        placeholder={`${label}을 입력해주세요.`}
+      />
+
+      <Input.Trigger />
+    </Input.Root>
+  );
+}

--- a/src/domain/User/components/ui/EditableAvatar.tsx
+++ b/src/domain/User/components/ui/EditableAvatar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChangeEvent, useCallback, useState } from 'react';
+import { ChangeEvent, useCallback, useEffect, useState } from 'react';
 
 import { PROFILE_AVATAR_OPTIONS } from '@/shared/components/constants/image';
 import Avatar from '@/shared/components/ui/avatar';
@@ -47,6 +47,11 @@ export default function EditableAvatar({
   // 낙관적 업데이트를 위해 즉시 미리보기 URL로 변경되었다가, 최종적으로 서버 URL로 교체됩니다.
   const [profileImageUrl, setProfileImageUrl] =
     useState<string>(initialImageUrl);
+
+  // initialImageUrl이 변경될 때 내부 상태를 동기화
+  useEffect(() => {
+    setProfileImageUrl(initialImageUrl);
+  }, [initialImageUrl]);
 
   // 이미지 압축 커스텀 훅
   const { compressImage, isCompressing } = useImageCompression();

--- a/src/domain/User/hooks/useUserInfoMutation.ts
+++ b/src/domain/User/hooks/useUserInfoMutation.ts
@@ -1,0 +1,60 @@
+import { useMutation } from '@tanstack/react-query';
+
+import {
+  UpdateUserInfoRequest,
+  UpdateUserInfoResponse,
+  UserInfoFormValues,
+} from '@/domain/User/schemas/userInfoForm';
+import { patchUserInfo } from '@/domain/User/services/patchUserInfo';
+import { useRoamReadyStore } from '@/shared/store';
+
+/**
+ * 사용자 정보 업데이트를 처리하는 mutation 훅
+ *
+ * 사용자의 닉네임, 프로필 이미지, 비밀번호 정보를 업데이트하고,
+ * 성공 시 전역 상태와 토스트 메시지를 업데이트합니다.
+ *
+ * @param currentProfileImageUrl - 현재 선택된 프로필 이미지 URL
+ * @returns TanStack Query의 useMutation 결과 객체
+ */
+export const useUserInfoMutation = (currentProfileImageUrl: string) => {
+  const { user, setUser, addToast } = useRoamReadyStore();
+
+  return useMutation({
+    mutationFn: async (
+      data: UserInfoFormValues,
+    ): Promise<UpdateUserInfoResponse> => {
+      if (!user) {
+        throw new Error('사용자 정보를 찾을 수 없습니다.');
+      }
+
+      // 이미지 URL 처리: 빈 문자열이면 null로 변환, 그렇지 않으면 현재 이미지 또는 기존 사용자 이미지 사용
+      const profileImageUrl = currentProfileImageUrl
+        ? currentProfileImageUrl
+        : user.profileImageUrl;
+
+      const requestData: UpdateUserInfoRequest = {
+        nickname: data.nickname,
+        profileImageUrl,
+        newPassword: data.password,
+      };
+
+      return patchUserInfo(requestData);
+    },
+    onSuccess: (updatedUser) => {
+      // Zustand 스토어 업데이트
+      setUser(updatedUser);
+      addToast({
+        message: '회원정보가 성공적으로 수정되었습니다.',
+        type: 'success',
+      });
+    },
+    onError: (error) => {
+      // API 에러 메시지 표시
+      addToast({
+        message: error.message || '회원정보 수정에 실패했습니다.',
+        type: 'error',
+      });
+    },
+  });
+};

--- a/src/domain/User/schemas/userInfoForm.ts
+++ b/src/domain/User/schemas/userInfoForm.ts
@@ -1,0 +1,48 @@
+import z from 'zod';
+
+import type { User } from '@/shared/slices/userSlice';
+
+/**
+ * 사용자 정보 폼 스키마
+ *
+ * 닉네임, 이메일, 비밀번호, 비밀번호 확인을 입력받고,
+ * 비밀번호는 8자 이상, 영문, 숫자, 특수문자를 포함해야 합니다.
+ * 비밀번호와 비밀번호 확인이 일치하지 않으면 에러 메시지를 반환합니다.
+ */
+export const userInfoFormSchema = z
+  .object({
+    nickname: z.string().min(1, { message: '닉네임을 입력해주세요.' }),
+    email: z.string().email({ message: '이메일 형식이 올바르지 않습니다.' }),
+    password: z
+      .string()
+      .min(1, { message: '비밀번호를 입력해주세요.' })
+      .regex(/^(?=.*[a-zA-Z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/, {
+        message: '비밀번호는 8자 이상, 영문, 숫자, 특수문자를 포함해야 합니다.',
+      }),
+    passwordConfirm: z
+      .string()
+      .min(1, { message: '비밀번호 확인을 입력해주세요.' }),
+  })
+  .refine((data) => data.password === data.passwordConfirm, {
+    message: '비밀번호가 일치하지 않습니다.',
+    path: ['passwordConfirm'],
+  });
+
+/**
+ * 사용자 정보 폼 값 타입
+ */
+export type UserInfoFormValues = z.infer<typeof userInfoFormSchema>;
+
+/**
+ * API 요청을 위한 사용자 정보 업데이트 요청 타입
+ */
+export interface UpdateUserInfoRequest {
+  nickname: string;
+  profileImageUrl: string | null;
+  newPassword: string;
+}
+
+/**
+ * API 응답을 위한 사용자 정보 업데이트 응답 타입
+ */
+export type UpdateUserInfoResponse = User;

--- a/src/domain/User/services/patchUserInfo.ts
+++ b/src/domain/User/services/patchUserInfo.ts
@@ -1,0 +1,25 @@
+import {
+  UpdateUserInfoRequest,
+  UpdateUserInfoResponse,
+} from '@/domain/User/schemas/userInfoForm';
+import { API_ENDPOINTS } from '@/shared/constants/endpoints';
+import { apiClient } from '@/shared/libs/apiClient';
+
+/**
+ * 사용자 정보를 업데이트하는 API 함수
+ *
+ * 사용자의 닉네임, 프로필 이미지 URL, 새 비밀번호 정보를 서버에 전송하여
+ * 사용자 정보를 업데이트합니다.
+ *
+ * @param data - 업데이트할 사용자 정보
+ * @returns 업데이트된 사용자 정보
+ */
+export const patchUserInfo = async (
+  data: UpdateUserInfoRequest,
+): Promise<UpdateUserInfoResponse> => {
+  return await apiClient
+    .patch(API_ENDPOINTS.USERS.ME, {
+      json: data,
+    })
+    .json<UpdateUserInfoResponse>();
+};

--- a/src/domain/User/services/uploadProfileImage.ts
+++ b/src/domain/User/services/uploadProfileImage.ts
@@ -1,0 +1,39 @@
+import ky from 'ky';
+
+import { BRIDGE_API } from '@/shared/constants/bridgeEndpoints';
+import { API_ENDPOINTS } from '@/shared/constants/endpoints';
+
+/**
+ * 프로필 이미지 업로드 응답 타입
+ */
+export interface UploadProfileImageResponse {
+  profileImageUrl: string;
+}
+
+/**
+ * 이미지 업로드 전용 API 클라이언트
+ * FormData 업로드에 최적화된 설정을 가집니다.
+ */
+const imageUploadClient = ky.create({
+  prefixUrl: BRIDGE_API.PREFIX,
+  timeout: 60000, // 60초 (이미지 업로드는 시간이 오래 걸릴 수 있음)
+  // Content-Type 헤더를 설정하지 않아 브라우저가 자동으로 multipart/form-data로 설정
+});
+
+/**
+ * 프로필 이미지를 서버에 업로드하는 API 함수
+ * @param imageFile - 업로드할 이미지 파일
+ * @returns 업로드된 이미지의 URL을 포함한 응답
+ */
+export const uploadProfileImage = async (
+  imageFile: File,
+): Promise<UploadProfileImageResponse> => {
+  const formData = new FormData();
+  formData.append('image', imageFile);
+
+  return await imageUploadClient
+    .post(API_ENDPOINTS.USERS.UPLOAD_IMAGE, {
+      body: formData,
+    })
+    .json<UploadProfileImageResponse>();
+};

--- a/src/shared/components/ui/avatar/index.tsx
+++ b/src/shared/components/ui/avatar/index.tsx
@@ -45,7 +45,7 @@ const avatarSizeStyles = {
  * 이미지 URL 유무에 따라 사용자 지정 이미지 또는 기본 로고를 렌더링하며,
  * 로딩 상태를 시각적으로 표현할 수 있습니다.
  *
- * @param profileImageUrl - 표시할 이미지 URL. Falsy 값일 경우 기본 로고가 표시됩니다.
+ * @param profileImageUrl - 표시할 이미지 URL. 빈 문자열, null, undefined일 경우 기본 로고가 표시됩니다.
  * @param size - 아바타 크기 프리셋 ('sm' 또는 'lg').
  * @param isLoading - 로딩 상태 여부.
  *
@@ -57,8 +57,8 @@ export default function Avatar({
   size = 'sm',
   isLoading = false,
 }: AvatarProps) {
-  // profileImageUrl이 빈 문자열('')이면 기본 이미지를 표시합니다.
-  const isDefaultImage = !profileImageUrl;
+  // profileImageUrl이 빈 문자열(''), null, undefined이면 기본 이미지를 표시합니다.
+  const isDefaultImage = !profileImageUrl || profileImageUrl.trim() === '';
 
   // size prop에 따라 해당되는 스타일 클래스와 sizes 속성을 가져옵니다.
   const { className, sizes } = avatarSizeStyles[size];

--- a/src/shared/constants/endpoints.ts
+++ b/src/shared/constants/endpoints.ts
@@ -71,5 +71,6 @@ export const API_ENDPOINTS = {
   USERS: {
     DETAIL: (userId: number) => `users/${userId}`,
     ME: 'users/me',
+    UPLOAD_IMAGE: 'users/me/image',
   },
 };


### PR DESCRIPTION
## 👻 관련 이슈 번호

<!-- 관련 이슈 번호가 있으면 #번호 적어주세요. -->

- close #391 

## 👻 요약

<!-- 구현 및 수정한 내용을 간단하게 적어주세요. -->

- 마이페이지의 내 정보 페이지 및 기능을 구현했습니다.

## 👻 주요 변경 사항

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요. -->

- Input 공통 컴포넌트 + RHF + Zod 기반 사용자 닉네임, 비밀번호 변경 Form을 구현했습니다.
- 유저 정보 수정 Form에는 `useRoamReadyStore`의 `user` slice에서 정보를 가져와서 필드를 미리 업데이트 해놓습니다. 그리고 정보가 수정되면 이 값을 업데이트 합니다.
- 유저 정보 변경 요청 서비스 함수를 만들고, `useMutation`의 `mutationFn`으로 사용하여 사용자 정보를 수정합니다.
- 사용자 정보 수정 성공/실패는 Toast를 통해 피드백을 받을 수 있도록 했습니다.
- 기존 EditableAvatar 컴포넌트에서 Mock API를 제거하고 실제 API와 요청/응답 받는 구조로 변경했습니다.

## 👻 체크리스트

<!-- PR 올리기 전에 체크리스트를 꼭 확인해주세요. -->

- [ ] Assignees에 본인을 등록했나요?
- [ ] 라벨을 사이드 탭에서 등록했나요?
- [ ] PR은 사이드 탭 Projects를 등록 **하지마세요.**
- [ ] PR은 Milestone을 등록 **하지마세요.**
- [ ] PR을 보내는 브랜치가 올바른지 확인했나요?
- [ ] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했나요?
- [ ] 변경사항을 충분히 테스트 했나요?
- [ ] 컨벤션에 맞게 구현했나요?

## 📷 UI 변경 사항

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

https://github.com/user-attachments/assets/ae4d6811-08cb-4c96-a012-7376d92f2aae



## 👻 문제 사항

<!-- 문제가 발생했다면 자세히 적어주세요.  -->

- 지금 헤더에 다음의 이미지와 같은 식으로 되어 있는데, 이 부분이 아직 변경이 안 된 건지 추후 PR 반영되면 해결되는지 여쭤보고 싶습니다!
<img width="1202" height="96" alt="{F4CDDBD8-B674-4CB1-B7E9-DD3573AA57B7}" src="https://github.com/user-attachments/assets/bc42b70f-809e-4010-a999-2235962c779d" />

- **토큰 자동 갱신 로직이 작동을 하지 않는 거 같습니다**. 아직 구현이 안 된 건지 통합이 안 된 건지 잘 모르겠어서, 제가 혹시 모르고 있는 부분이 있다면 알려주시면 감사하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 마이페이지에서 프로필 이미지 및 닉네임, 비밀번호 변경이 가능한 사용자 정보 수정 폼이 추가되었습니다.
  * 프로필 이미지를 즉시 미리보기 및 업로드할 수 있으며, 실패 시 자동으로 롤백됩니다.

* **버그 수정**
  * 프로필 이미지가 공백 문자열일 경우에도 기본 이미지가 표시되도록 개선되었습니다.

* **개선 사항**
  * 외부 이미지 호스트에서 이미지를 불러올 수 있도록 이미지 최적화 설정이 추가되었습니다.
  * 사용자 정보 입력 폼의 유효성 검사와 에러 메시지가 강화되었습니다.

* **문서**
  * 일부 컴포넌트의 설명이 더 명확하게 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->