### PR TITLE
Refactor: 상세 2차 QA 반영

### DIFF
--- a/src/app/(app)/activities/[id]/layout.tsx
+++ b/src/app/(app)/activities/[id]/layout.tsx
@@ -1,19 +1,5 @@
 import { ReactNode } from 'react';
 
-/**
- * @component AppLayout
- * @description
- * 메인 애플리케이션의 공통 레이아웃을 정의하는 컴포넌트입니다.
- * 모든 페이지에 걸쳐 일관된 UI(헤더, 푸터)를 제공하며,
- * `AuthStatusProvider`를 통해 사용자 인증 상태를 관리하고 하위 컴포넌트에 제공합니다.
- *
- * 이 컴포넌트는 전체 페이지의 최소 높이를 설정하고, 콘텐츠 영역에 반응형 패딩 및 최대 너비를 적용합니다.
- *
- * @param {AppLayoutProps} props - 컴포넌트의 props입니다.
- * @param {ReactNode} props.children - 이 레이아웃 내부에 렌더링될 자식 요소입니다.
- *
- * @returns {JSX.Element} 헤더, 콘텐츠 영역(AuthStatusProvider 포함), 푸터로 구성된 React 요소입니다.
- */
 export default function ActivityDetailLayout({
   children,
 }: {

--- a/src/app/(app)/activities/[id]/page.tsx
+++ b/src/app/(app)/activities/[id]/page.tsx
@@ -52,7 +52,7 @@ export default async function ActivityDetailPage({ params }: PageParams) {
   return (
     <>
       {/* PC / Tablet 레이아웃 */}
-      <div className='desktop:pt-60 desktop:pb-180 tablet:pb-80 desktop:flex-row flex w-full flex-col gap-30 pt-30 pb-20'>
+      <div className='desktop:pt-10 desktop:pb-180 tablet:pb-80 desktop:flex-row flex w-full flex-col gap-30 pt-30 pb-20'>
         {/* 왼쪽 메인 콘텐츠 영역 */}
         <div className='flex w-full flex-col gap-40'>
           <ActivityImg

--- a/src/domain/Activity/components/detail/Reservation/AvailableTimeSection.tsx
+++ b/src/domain/Activity/components/detail/Reservation/AvailableTimeSection.tsx
@@ -109,7 +109,7 @@ export default function AvailableTimeSection({
         </div>
 
         {/* 흐림 효과: 타임 슬롯이 많아 스크롤이 필요한 경우 하단 fade 효과 표시 */}
-        {filteredSlots.length >= 3 && (
+        {filteredSlots.length >= 4 && (
           <div className='pointer-events-none absolute bottom-0 left-0 h-20 w-full bg-gradient-to-t from-white to-transparent' />
         )}
       </div>

--- a/src/domain/Activity/components/detail/Reservation/ReservationMobile.tsx
+++ b/src/domain/Activity/components/detail/Reservation/ReservationMobile.tsx
@@ -39,6 +39,7 @@ export default function ReservationMobile({
     reservableDates,
     timeSlots,
     selectedScheduleId,
+    setParticipantCount,
     setSelectedDate,
     setSelectedTime,
     handleTimeSelect,
@@ -59,9 +60,11 @@ export default function ReservationMobile({
     if (result.statusCode !== 200) {
       showError(result.message);
       setSelectedDate(null);
+      setParticipantCount(1);
       return;
     }
 
+    setParticipantCount(1);
     setSelectedDate(null);
     showSuccess(result.message);
   };

--- a/src/domain/Activity/components/detail/Reservation/ReservationPC.tsx
+++ b/src/domain/Activity/components/detail/Reservation/ReservationPC.tsx
@@ -74,7 +74,7 @@ export default function ReservationPC({
       className='h-fit max-h-950 w-full rounded-4xl border-1 border-gray-50 bg-white p-30 shadow-[0_4px_20px_rgba(0,0,0,0.05)]'
     >
       {/* Todo: form action 연결 */}
-      <form className='flex flex-col gap-24' onSubmit={handleSubmit}>
+      <form className='flex flex-col gap-15' onSubmit={handleSubmit}>
         {/* 가격 정보 */}
         <section aria-labelledby='pricing'>
           <div className='flex items-center gap-8'>
@@ -109,7 +109,7 @@ export default function ReservationPC({
           timeSlots={timeSlots}
           selectedTime={selectedTime}
           onTimeSelect={handleTimeSelect}
-          className='max-h-250'
+          className='max-h-150'
         />
 
         {/* 총 합계 및 예약 버튼 */}

--- a/src/domain/Activity/components/detail/Reservation/ReservationPC.tsx
+++ b/src/domain/Activity/components/detail/Reservation/ReservationPC.tsx
@@ -36,6 +36,7 @@ export default function ReservationPC({
     timeSlots,
     totalPrice,
     selectedScheduleId,
+    setParticipantCount,
     setSelectedDate,
     setSelectedTime,
     handleTimeSelect,
@@ -58,9 +59,11 @@ export default function ReservationPC({
     if (result.statusCode !== 200) {
       showError(result.message);
       setSelectedDate(null);
+      setParticipantCount(1);
       return;
     }
 
+    setParticipantCount(1);
     setSelectedDate(null);
     showSuccess(result.message);
   };

--- a/src/domain/Activity/components/detail/Reservation/ReservationTablet.tsx
+++ b/src/domain/Activity/components/detail/Reservation/ReservationTablet.tsx
@@ -39,6 +39,7 @@ export default function ReservationTablet({
     reservableDates,
     timeSlots,
     selectedScheduleId,
+    setParticipantCount,
     setSelectedDate,
     setSelectedTime,
     handleTimeSelect,
@@ -59,9 +60,11 @@ export default function ReservationTablet({
     if (result.statusCode !== 200) {
       showError(result.message);
       setSelectedDate(null);
+      setParticipantCount(1);
       return;
     }
 
+    setParticipantCount(1);
     setSelectedDate(null);
     showSuccess(result.message);
   };

--- a/src/domain/Activity/components/detail/Review/ExpandableReview.tsx
+++ b/src/domain/Activity/components/detail/Review/ExpandableReview.tsx
@@ -8,70 +8,61 @@ interface ExpandableReviewProps {
   text: string;
 }
 
-/**
- * ExpandableReview 컴포넌트
- *
- * 긴 리뷰 내용을 처음에는 3줄로 줄여 보여주고,
- * 사용자가 TriangleArrow를 클릭하면 전체 내용을 펼쳐볼 수 있도록 하는 컴포넌트입니다.
- *
- * - 줄 수 기준 말줄임(`-webkit-line-clamp`) 사용
- * - 텍스트가 줄 수를 초과하는 경우에만 "더보기" 버튼이 표시됨
- * - 디바이스 크기 변경 시에도 오버플로우 여부 재확인
- */
 export default function ExpandableReview({ text }: ExpandableReviewProps) {
-  const [isExpanded, setIsExpanded] = useState(false); // 전체 보기 여부 상태
-  const [showToggle, setShowToggle] = useState(false); // 더보기 (TriangleArrow) 버튼 표시 여부
-  const contentRef = useRef<HTMLParagraphElement>(null); // 텍스트 DOM 참조
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [showToggle, setShowToggle] = useState(false);
+  const contentRef = useRef<HTMLDivElement>(null);
 
-  /**
-   * 실제 오버플로우 여부 판단 함수
-   * - clamp 상태에서 scrollHeight가 offsetHeight보다 크면 말줄임 발생
-   */
-  const checkOverflow = () => {
-    const el = contentRef.current;
-    if (!el) return;
-    const isOverflowing = el.scrollHeight > el.offsetHeight;
-    setShowToggle(isOverflowing);
-  };
+  const COLLAPSED_LINE_COUNT = 5;
+  const LINE_HEIGHT = 24;
+  const collapsedMaxHeight = COLLAPSED_LINE_COUNT * LINE_HEIGHT;
 
-  /**
-   * 컴포넌트 마운트 시와 텍스트가 변경될 때 overflow 체크
-   * - DOM 렌더링 완료 후 체크하기 위해 requestAnimationFrame 사용
-   */
   useEffect(() => {
     requestAnimationFrame(() => {
-      checkOverflow();
+      const el = contentRef.current;
+      if (el && el.scrollHeight > collapsedMaxHeight + 5) {
+        setShowToggle(true);
+      }
     });
   }, [text]);
 
-  /**
-   * 윈도우 리사이즈 시에도 오버플로우 상태 재확인
-   * - 디바이스 크기에 따라 텍스트 줄 수가 달라질 수 있기 때문
-   */
   useEffect(() => {
-    window.addEventListener('resize', checkOverflow);
-    return () => window.removeEventListener('resize', checkOverflow);
+    const handleResize = () => {
+      const el = contentRef.current;
+      if (el && el.scrollHeight > collapsedMaxHeight + 5) {
+        setShowToggle(true);
+      } else {
+        setShowToggle(false);
+      }
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
   }, []);
 
   return (
-    <div className='relative w-full'>
-      {/* 리뷰 본문 텍스트 */}
-      <p
+    <div className='w-full'>
+      {/* 본문 텍스트 */}
+      <div
         ref={contentRef}
-        className={`font-size-16 line-height-1.5 transition-height font-medium break-words whitespace-pre-line text-gray-950 duration-500 ease-in-out ${
-          isExpanded ? 'clamp-none' : 'clamp-multiline'
+        className={`font-size-16 relative overflow-hidden font-medium break-words whitespace-pre-line text-gray-950 transition-all duration-900 ease-in-out ${
+          isExpanded ? 'max-h-[1000px] opacity-80' : 'max-h-[120px] opacity-100'
         }`}
       >
         {text}
-      </p>
 
-      {/* 더보기 / 접기 버튼 */}
+        {/* 말줄임용 그라디언트 */}
+        {!isExpanded && showToggle && (
+          <div className='pointer-events-none absolute bottom-0 left-0 h-10 w-full bg-gradient-to-t from-white via-white/100 to-transparent transition-opacity duration-500' />
+        )}
+      </div>
+
+      {/* 더보기 버튼 */}
       {showToggle && (
-        <div className='text-center'>
+        <div className='mt-8 text-center'>
           <button
             type='button'
             onClick={() => setIsExpanded((prev) => !prev)}
-            className='font-size-12 mt-10 cursor-pointer text-gray-800 underline'
+            className='font-size-12 cursor-pointer text-gray-800 underline'
           >
             {isExpanded ? (
               <TriangleArrow

--- a/src/domain/Activity/components/detail/activity-img/ImageModal.tsx
+++ b/src/domain/Activity/components/detail/activity-img/ImageModal.tsx
@@ -94,13 +94,17 @@ export default function ImageModal({
       </button>
 
       {/* 이전 이미지 버튼 */}
-      <button
-        className='absolute left-4 z-10 cursor-pointer text-5xl text-white'
-        onClick={() => setIndex((i) => (i - 1 + images.length) % images.length)}
-        aria-label='이전 이미지 보기'
-      >
-        &#8592;
-      </button>
+      {images.length > 1 && (
+        <button
+          className='absolute left-4 z-10 cursor-pointer text-5xl text-white'
+          onClick={() =>
+            setIndex((i) => (i - 1 + images.length) % images.length)
+          }
+          aria-label='이전 이미지 보기'
+        >
+          &#8592;
+        </button>
+      )}
 
       {/* 이미지 표시 영역 */}
       <div
@@ -122,13 +126,15 @@ export default function ImageModal({
       </div>
 
       {/* 다음 이미지 버튼 */}
-      <button
-        className='absolute right-4 z-10 cursor-pointer text-5xl text-white'
-        onClick={() => setIndex((i) => (i + 1) % images.length)}
-        aria-label='다음 이미지 보기'
-      >
-        &#8594;
-      </button>
+      {images.length > 1 && (
+        <button
+          className='absolute right-4 z-10 cursor-pointer text-5xl text-white'
+          onClick={() => setIndex((i) => (i + 1) % images.length)}
+          aria-label='다음 이미지 보기'
+        >
+          &#8594;
+        </button>
+      )}
     </div>
   );
 }

--- a/src/domain/Activity/components/detail/activity-summary/ActivityDropdown.tsx
+++ b/src/domain/Activity/components/detail/activity-summary/ActivityDropdown.tsx
@@ -1,11 +1,13 @@
 'use client';
 
+import { useQueryClient } from '@tanstack/react-query';
 import { EllipsisVertical } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
 import DeleteModalContent from '@/domain/Activity/components/detail/activity-summary/DeleteModalContent';
 import { useDeleteMyActivity } from '@/domain/Activity/hooks/detail/useDeleteMyActivity';
+import { activitiesKeys } from '@/domain/Activity/libs/main/queryKeys';
 import Button from '@/shared/components/Button';
 import { Dialog } from '@/shared/components/ui/dialog';
 import Dropdown from '@/shared/components/ui/dropdown';
@@ -31,6 +33,7 @@ export default function ActivityDropdown({
   ownerId,
 }: ActivityDropdownProps) {
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   // 전역 상태에서 현재 로그인한 사용자 정보 가져오기
   const user = useRoamReadyStore((state) => state.user);
@@ -53,6 +56,7 @@ export default function ActivityDropdown({
   const handleDelete = async () => {
     try {
       await deleteActivity(id);
+      queryClient.invalidateQueries({ queryKey: activitiesKeys.all });
       router.push('/activities');
     } catch (e) {
       console.error(e);

--- a/src/domain/Activity/components/detail/responsive-wrappers/ReservationWrapper.tsx
+++ b/src/domain/Activity/components/detail/responsive-wrappers/ReservationWrapper.tsx
@@ -72,16 +72,18 @@ export default function ReservationWrapper({
     // 일반 사용자 (PC, 로그인, 소유자 아님) → 예약 폼 노출
     return (
       <div
-        className='sticky flex flex-col gap-38'
+        className='sticky'
         style={{
           top: 120,
           height: heightValue,
         }}
       >
-        <div className='w-400'>
-          <ActivitySummary activity={activity} review={reviews} />
+        <div className='scrollbar-none flex h-full flex-col gap-30 overflow-y-auto'>
+          <div className='w-400'>
+            <ActivitySummary activity={activity} review={reviews} />
+          </div>
+          <ReservationPC activity={activity} reservation={reservation} />
         </div>
-        <ReservationPC activity={activity} reservation={reservation} />
       </div>
     );
   }

--- a/src/domain/Activity/hooks/detail/useReservationForm.ts
+++ b/src/domain/Activity/hooks/detail/useReservationForm.ts
@@ -120,6 +120,7 @@ export const useReservationForm = (
     totalPrice,
 
     // 상태 제어 함수 반환
+    setParticipantCount,
     setSelectedDate,
     setSelectedTime,
     handleTimeSelect,

--- a/src/domain/Notification/services/index.ts
+++ b/src/domain/Notification/services/index.ts
@@ -11,7 +11,7 @@ import { apiClient } from '@/shared/libs/apiClient';
  */
 export const getNotifications = async ({
   cursorId,
-  size = 10,
+  size = 3,
 }: {
   cursorId?: number;
   size?: number;

--- a/src/shared/components/ui/Pagination/index.tsx
+++ b/src/shared/components/ui/Pagination/index.tsx
@@ -110,6 +110,11 @@ export default function Pagination({
     if (isInvalid) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
+      const modalIsOpen = document.querySelector(
+        '[role="dialog"][aria-modal="true"]',
+      );
+      if (modalIsOpen) return;
+
       let nextPage = currentPage;
 
       if (e.key === 'ArrowLeft' && currentPage > 1) {


### PR DESCRIPTION
## 👻 관련 이슈 번호

<!-- 관련 이슈 번호가 있으면 #번호 적어주세요. -->

- 452

## 👻 요약

<!-- 구현 및 수정한 내용을 간단하게 적어주세요. -->

- 2차 QA에서 받은 피드백 사항 수정했습니다.

## 👻 주요 변경 사항

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요. -->

- [x] 상세페이지 이미 모달 켜졌을 때 페이지네이션 포커스 막기
- [x] Reservation Sticky → 해당 영역만 스크롤 가능 하도록
- [x] Reservation 폼 제출 시 참여 인원 수 초기화
- [x] 이미지 모달 length 1개일 때 안 보이도록
- [x] 체험 삭제 시 메인 페이지 즉시 반영
- [x] Notification 요청 보내는 횟수 줄이기 (10개 → 3개) 
- [x] 리뷰 카드 Transition 부드럽게 변경

## 👻 체크리스트

<!-- PR 올리기 전에 체크리스트를 꼭 확인해주세요. -->

- [ ] Assignees에 본인을 등록했나요?
- [ ] 라벨을 사이드 탭에서 등록했나요?
- [ ] PR은 사이드 탭 Projects를 등록 **하지마세요.**
- [ ] PR은 Milestone을 등록 **하지마세요.**
- [ ] PR을 보내는 브랜치가 올바른지 확인했나요?
- [ ] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했나요?
- [ ] 변경사항을 충분히 테스트 했나요?
- [ ] 컨벤션에 맞게 구현했나요?

## 📷 UI 변경 사항

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

### 이미지 1개일 경우 좌,우 버튼 없애기
<img width="1912" height="991" alt="스크린샷 2025-08-03 150158" src="https://github.com/user-attachments/assets/b21ac0a8-a3b5-492e-9158-7fb56390e6e7" />

### 리뷰 카드 효과 부드럽게
![리뷰 카드 부드럽게](https://github.com/user-attachments/assets/255c8817-2c01-4a72-82ae-5576c0520030)

### 이미지 모달 열렸을 때 페이지네이션 키보드 이벤트 방지
(용량이 커서 더 이상 영상이 올라가지 않는 것 같습니다 ㅠㅠ Preview 링크에서 확인 부탁드립니다!)


## 👻 문제 사항

<!-- 문제가 발생했다면 자세히 적어주세요.  -->

-

## 👻 논의 사항

<!-- 논의하고 싶은 사항을 적어 주시고, 토론이 필요하시면 토론 탭에 추가 부탁드립니다. -->

-

## 👻 기타 참고 사항

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주세요. -->

- 제가 놓친 수정 사항이 있다면 말씀해주시면 반영하겠습니다.
- 예약 영역은 내부에서도 스크롤 가능하게 했는데, 전체 페이지 크기 만큼만 스크롤이 가능해 예약 가능한 시간 영역 및 내부 gap 조정으로 최대한 예약 버튼이 노출될 수 있도록 조정하긴 했습니다.
- 다만, 페이지내부 크기 만큼만 스크롤이 가능해 페이지 스크롤이 다 내려와야 예약 버튼이 전부 노출될 수 있습니다..
- 혹시 이 부분에 대해 해결할 수 있는 방법이 있다면 말씀해주시면 감사하겠습니다 ㅠㅠ
