### PR TITLE
Refactor: 리팩토링3

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -30,13 +30,5 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
         <Footer />
       </div>
     </ClientSessionProvider>
-
-    // <div className='flex min-h-[100dvh] flex-col'>
-    //   <Header />
-    //   <main className='tablet:px-32 desktop:px-40 mx-auto w-full max-w-1920 flex-1 px-24 py-20'>
-    //     <AuthStatusProvider>{children}</AuthStatusProvider>
-    //   </main>
-    //   <Footer />
-    // </div>
   );
 }

--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -17,6 +17,7 @@ import { ROUTES } from '@/shared/constants/routes';
  * <Suspense> 바운더리로 래핑합니다.
  */
 export default function SignInPage() {
+  // 아래는 스켈레톤 확인용
   // await new Promise((resolve) => setTimeout(resolve, 5000));
 
   return (

--- a/src/app/api/auth/kakao/callback/route.ts
+++ b/src/app/api/auth/kakao/callback/route.ts
@@ -106,7 +106,7 @@ async function handleOauthSignIn(
 export async function GET(request: NextRequest) {
   try {
     const code = request.nextUrl.searchParams.get('code');
-    const intent = request.nextUrl.searchParams.get('state');
+    const state = request.nextUrl.searchParams.get('state');
 
     if (!code) {
       throw Object.assign(new Error('카카오 인증 코드가 없습니다.'), {
@@ -114,9 +114,17 @@ export async function GET(request: NextRequest) {
       });
     }
 
+    if (!state) {
+      throw Object.assign(new Error('OAuth state 파라미터가 없습니다.'), {
+        status: 400,
+      });
+    }
+
+    const [intent] = state.split(':');
+
     let responseData;
     if (intent === 'signup') {
-      const arbitraryNickname = `KakaoUser_${crypto.randomUUID().slice(0, 8)}`;
+      const arbitraryNickname = `K_${crypto.randomUUID().replace(/-/g, '').slice(0, 7)}`;
       responseData = await handleOauthSignUp(code, arbitraryNickname);
     } else if (intent === 'signin') {
       responseData = await handleOauthSignIn(code);

--- a/src/app/api/auth/signin/route.ts
+++ b/src/app/api/auth/signin/route.ts
@@ -6,12 +6,7 @@ import { handleApiError } from '@/shared/utils/errors/handleApiError';
 
 /**
  * @file /api/auth/signin/route.ts
- * @description 클라이언트의 로그인 요청을 처리하고, 성공 시 인증 쿠키를 발급하는 API 라우트 핸들러입니다.
- * @see /src/app/(auth)/signin/page.tsx - 이 API를 호출하는 클라이언트 페이지
- * @see /src/shared/constants/endpoints.ts - `API_ENDPOINTS` 상수 정의
- *
- * @description
- * 클라이언트의 로그인 요청을 BFF(Backend for Frontend) 서버에서 처리합니다.
+ * @description 클라이언트의 로그인 요청을 BFF(Backend for Frontend) 서버에서 처리하고, 성공 시 인증 쿠키를 발급하는 API 라우트 핸들러입니다.
  *
  * ### 주요 로직:
  * 1.  클라이언트로부터 `email`, `password`의 유효성을 Zod 스키마로 검사합니다.
@@ -38,6 +33,9 @@ import { handleApiError } from '@/shared/utils/errors/handleApiError';
  *
  * @param {NextRequest} request - 클라이언트의 요청 객체. `email`, `password`를 포함합니다.
  * @returns {Promise<NextResponse>} 처리 결과에 따른 응답 객체.
+ *
+ * @see /src/app/(auth)/signin/page.tsx - 이 API를 호출하는 클라이언트 페이지
+ * @see /src/shared/constants/endpoints.ts - `API_ENDPOINTS` 상수 정의
  */
 export async function POST(request: NextRequest) {
   try {

--- a/src/app/api/auth/signout/route.ts
+++ b/src/app/api/auth/signout/route.ts
@@ -2,11 +2,9 @@ import { NextResponse } from 'next/server';
 
 /**
  * @file /api/auth/signout/route.ts
- * @description 사용자의 로그아웃 요청을 처리하여 인증 쿠키를 삭제하는 API 라우트 핸들러입니다.
- * @see /src/shared/hooks/useSignout.ts - 이 API를 호출하는 클라이언트 훅
  *
  * @description
- * 클라이언트의 로그아웃 요청을 받아 서버에 저장된 인증 관련 쿠키를 삭제합니다.
+ * 클라이언트의 로그아웃 요청을 받아 서버에 저장된 인증 관련 쿠키를 삭제하는 API 라우트 핸들러입니다.
  * 이 API는 멱등성(Idempotency)을 가집니다. 즉, 여러 번 호출해도 결과는 항상 동일한 '로그아웃 상태'가 됩니다.
  *
  * ### 주요 로직:
@@ -28,6 +26,8 @@ import { NextResponse } from 'next/server';
  * 6.  **`onError` 콜백**: 바로 이곳에서 `toast.show(error.message, { type: 'error' })` 코드가 실행되어, 최종적으로 사용자에게 토스트 메시지가 보이게 됩니다.
  *
  * @returns {Promise<NextResponse>} 처리 결과에 따른 응답 객체.
+ *
+ * @see /src/shared/hooks/useSignout.ts - 이 API를 호출하는 클라이언트 훅
  */
 export async function POST() {
   try {

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -7,12 +7,9 @@ import { handleApiError } from '@/shared/utils/errors/handleApiError';
 
 /**
  * @file /api/auth/signup/route.ts
- * @description 클라이언트의 회원가입 요청을 처리하고, 성공 시 자동 로그인시키는 API 라우트 핸들러입니다.
- * @see /src/app/(auth)/signup/page.tsx - 이 API를 호출하는 클라이언트 페이지
- * @see /src/shared/constants/endpoints.ts - `API_ENDPOINTS` 상수 정의
  *
  * @description
- * 클라이언트의 회원가입 요청을 BFF(Backend for Frontend) 서버에서 처리합니다.
+ * 클라이언트의 회원가입 요청을 BFF(Backend for Frontend) 서버에서 처리하고, 성공 시 자동 로그인시키는 API 라우트 핸들러입니다.
  * 백엔드 API가 회원가입 시 토큰을 반환하지 않으므로, 회원가입 성공 후 즉시 로그인 API를 호출하여 토큰을 받아옵니다.
  *
  * ### 주요 로직:
@@ -40,6 +37,9 @@ import { handleApiError } from '@/shared/utils/errors/handleApiError';
  *
  * @param {NextRequest} request - 클라이언트의 요청 객체. `email`, `password`, `nickname`을 포함합니다.
  * @returns {Promise<NextResponse>} 처리 결과에 따른 응답 객체.
+ *
+ * @see /src/app/(auth)/signup/page.tsx - 이 API를 호출하는 클라이언트 페이지
+ * @see /src/shared/constants/endpoints.ts - `API_ENDPOINTS` 상수 정의
  */
 export async function POST(request: NextRequest) {
   try {

--- a/src/domain/Auth/components/SignInForm.tsx
+++ b/src/domain/Auth/components/SignInForm.tsx
@@ -15,8 +15,6 @@ import Input from '@/shared/components/ui/input';
  * 이메일/비밀번호를 이용한 로그인 폼의 UI와 상태 관리, 제출 로직을 담당하는 클라이언트 컴포넌트입니다.
  * 로그인 성공 시, 전역 상태를 업데이트하고 메인 페이지로 이동합니다.
  *
- * @see /src/app/api/auth/signin/route.ts - 로그인을 처리하는 API 라우트
- *
  * @feature
  * - **폼 관리**: `react-hook-form`의 `useForm`을 사용하여 폼의 상태를 관리합니다.
  * - **유효성 검사**: `zodResolver`를 이용해 클라이언트 측 유효성 검사를 실시간으로 수행합니다.
@@ -24,6 +22,8 @@ import Input from '@/shared/components/ui/input';
  * - **전역 상태 업데이트**: 로그인 성공 시, 전역 Zustand 스토어에 사용자 정보를 저장하고 관련 캐시를 무효화합니다.
  * - **사용자 피드백**: `useToast` 훅을 통해 로그인 성공 또는 실패에 대한 명확한 피드백(토스트 메시지)을 제공합니다. OAuth 관련 에러는 URL 쿼리 파라미터를 통해 받아 처리합니다.
  * - **에러 핸들링**: `useSigninMutation` 훅 내부에서 `ky`의 `HTTPError`를 감지하여 네트워크 에러 메시지 및 서버 응답 에러를 사용자에게 보여줍니다.
+ *
+ * @see /src/app/api/auth/signin/route.ts - 로그인을 처리하는 API 라우트
  */
 export default function SignInForm() {
   const { mutate, isPending } = useSigninMutation();

--- a/src/domain/Auth/components/SignUpForm.tsx
+++ b/src/domain/Auth/components/SignUpForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useEffect } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { useSignupMutation } from '@/domain/Auth/hooks/useSignupMutation';
@@ -23,8 +24,8 @@ import Input from '@/shared/components/ui/input';
  * - **유효성 검사**: `zodResolver`를 이용해 클라이언트 측 유효성 검사를 실시간으로 수행하며, 서버 응답 에러(예: 이메일 중복)를 `react-hook-form`의 `setError`를 통해 특정 필드에 직접 표시합니다.
  * - **제출 중 로딩 상태 관리**: `isSubmitting` 및 `isPending` 상태를 활용하여 API 요청 중에는 버튼을 비활성화하고 로딩 상태를 표시합니다.
  * - **자동 로그인**: 회원가입 성공 시, 즉시 로그인 상태로 전환하며 전역 Zustand 스토어에 사용자 정보를 저장하고 관련 캐시를 무효화합니다.
- * - **사용자 피드백**: `useToast` 훅을 통해 회원가입 성공 또는 실패에 대한 명확한 피드백(토스트 메시지)을 제공합니다. OAuth 관련 에러는 URL 쿼리 파라미터를 통해 받아 처리합니다.
  * - **에러 핸들링**: `useSignupMutation` 훅 내부에서 `ky`의 `HTTPError`를 감지하여 네트워크 에러 메시지 및 서버 응답 에러를 사용자에게 보여줍니다.
+ *  - **세션 스토리지 기반 임시 저장**: 이메일/닉네임 입력값을 `sessionStorage`에 자동 저장하고 페이지 재방문 시 복구
  *
  * @see /src/app/api/auth/signup/route.ts - 자동 로그인을 처리하는 API 라우트
  */
@@ -45,12 +46,37 @@ export default function SignUpForm() {
   const {
     handleSubmit,
     formState: { isSubmitting, isValid },
+    watch,
   } = form;
+
+  useEffect(() => {
+    const saved = sessionStorage.getItem('signup-form');
+    if (saved) {
+      const parsed = JSON.parse(saved);
+      form.reset({
+        ...form.getValues(),
+        email: parsed.email || '',
+        nickname: parsed.nickname || '',
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    const subscription = watch((value) => {
+      const { email, nickname } = value;
+      sessionStorage.setItem(
+        'signup-form',
+        JSON.stringify({ email, nickname }),
+      );
+    });
+    return () => subscription.unsubscribe();
+  }, [watch]);
 
   const { mutate, isPending } = useSignupMutation(form);
 
   const onSubmit = (data: SignupRequest) => {
     mutate(data);
+    sessionStorage.removeItem('signup-form');
   };
 
   return (

--- a/src/domain/Auth/components/SignUpForm.tsx
+++ b/src/domain/Auth/components/SignUpForm.tsx
@@ -50,14 +50,19 @@ export default function SignUpForm() {
   } = form;
 
   useEffect(() => {
-    const saved = sessionStorage.getItem('signup-form');
-    if (saved) {
-      const parsed = JSON.parse(saved);
-      form.reset({
-        ...form.getValues(),
-        email: parsed.email || '',
-        nickname: parsed.nickname || '',
-      });
+    try {
+      const saved = sessionStorage.getItem('signup-form');
+      if (saved) {
+        const parsed = JSON.parse(saved);
+        form.reset({
+          ...form.getValues(),
+          email: parsed.email || '',
+          nickname: parsed.nickname || '',
+        });
+      }
+    } catch (error) {
+      console.warn('[Session Storage Error]:', error);
+      sessionStorage.removeItem('signup-form');
     }
   }, []);
 
@@ -93,7 +98,7 @@ export default function SignUpForm() {
 
         <Input.Root id='nickname' name='nickname' type='text'>
           <Input.Label>닉네임</Input.Label>
-          <Input.Field placeholder='닉네임을 작성해주세요' />
+          <Input.Field placeholder='닉네임을 작성해주세요' maxLength={11} />
           <Input.Helper />
         </Input.Root>
 

--- a/src/domain/Auth/components/SignUpForm.tsx
+++ b/src/domain/Auth/components/SignUpForm.tsx
@@ -18,8 +18,6 @@ import Input from '@/shared/components/ui/input';
  * 이메일/닉네임/비밀번호를 이용한 회원가입 폼의 UI와 상태 관리, 제출 로직을 담당하는 클라이언트 컴포넌트입니다.
  * 회원가입 성공 시, 자동으로 로그인 상태를 만들고 메인 페이지로 이동시킵니다.
  *
- * @see /src/app/api/auth/signup/route.ts - 자동 로그인을 처리하는 API 라우트
- *
  * @feature
  * - **폼 관리**: `react-hook-form`의 `useForm`을 사용하여 폼의 상태를 관리합니다.
  * - **유효성 검사**: `zodResolver`를 이용해 클라이언트 측 유효성 검사를 실시간으로 수행하며, 서버 응답 에러(예: 이메일 중복)를 `react-hook-form`의 `setError`를 통해 특정 필드에 직접 표시합니다.
@@ -27,6 +25,8 @@ import Input from '@/shared/components/ui/input';
  * - **자동 로그인**: 회원가입 성공 시, 즉시 로그인 상태로 전환하며 전역 Zustand 스토어에 사용자 정보를 저장하고 관련 캐시를 무효화합니다.
  * - **사용자 피드백**: `useToast` 훅을 통해 회원가입 성공 또는 실패에 대한 명확한 피드백(토스트 메시지)을 제공합니다. OAuth 관련 에러는 URL 쿼리 파라미터를 통해 받아 처리합니다.
  * - **에러 핸들링**: `useSignupMutation` 훅 내부에서 `ky`의 `HTTPError`를 감지하여 네트워크 에러 메시지 및 서버 응답 에러를 사용자에게 보여줍니다.
+ *
+ * @see /src/app/api/auth/signup/route.ts - 자동 로그인을 처리하는 API 라우트
  */
 export default function SignUpForm() {
   const signupDefaultValues: SignupFormValues = {

--- a/src/domain/Auth/hooks/useSigninMutation.ts
+++ b/src/domain/Auth/hooks/useSigninMutation.ts
@@ -19,7 +19,8 @@ import { useRoamReadyStore } from '@/shared/store';
  * - `data` (SigninResponse): 로그인 API 호출의 결과 데이터입니다.
  * - 전역 Zustand 스토어의 `setUser` 함수를 통해 로그인된 사용자 정보(`data.user`)를 업데이트합니다.
  * - `queryClient.invalidateQueries({ queryKey: ['user', 'me'] })`를 호출하여 'user', 'me' 쿼리 키에 해당하는 캐시를 무효화합니다. `queryClient`는 Tanstack Query의 중앙 캐시 관리자이며, `invalidateQueries`는 특정 쿼리 키에 해당하는 캐시 데이터를 '오래된' 상태로 표시하여 다음 번에 해당 데이터를 사용할 때 서버에서 최신 정보를 다시 가져오도록 강제합니다. 이는 로그인 후 사용자 정보가 변경되었을 수 있으므로 최신 정보를 다시 가져오도록 합니다.
- * - `showSuccess` 토스트 메시지('로그인 되었습니다. 환영합니다!')를 표시하고 메인 페이지(`ROUTES.ACTIVITIES.ROOT`)로 리다이렉트합니다.
+ * - 세션 스토리지에 임시 저장된 회원가입 이메일/닉네임(`signup-form`)을 `sessionStorage.removeItem('signup-form')`을 통해 제거하여 로그인 직후 상태를 초기화합니다.
+ * - 메인 페이지(`ROUTES.ACTIVITIES.ROOT`)로 리다이렉트합니다.
  *
  * @property {Function} onError - `mutationFn`이 실패했을 때 실행되는 콜백 함수입니다.
  * - `error` (Error): 발생한 에러 객체입니다. 이 `error.message`는 `formatErrorResponseHooks`에 의해 이미 사용자 친화적인 메시지로 가공되어 있습니다.
@@ -39,6 +40,7 @@ export const useSigninMutation = () => {
   return useMutation({
     mutationFn: signin,
     onSuccess: (data: SigninResponse) => {
+      sessionStorage.removeItem('signup-form');
       setUser(data.user);
       queryClient.invalidateQueries({ queryKey: ['user', 'me'] });
       // showSuccess('로그인 되었습니다. 환영합니다!');

--- a/src/domain/Auth/hooks/useSigninMutation.ts
+++ b/src/domain/Auth/hooks/useSigninMutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { HTTPError } from 'ky';
-import { useRouter } from 'next/navigation';
 
+// import { useRouter } from 'next/navigation';
 import type { SigninResponse } from '@/domain/Auth/schemas/response';
 import { signin } from '@/domain/Auth/services';
 import { ROUTES } from '@/shared/constants/routes';
@@ -31,7 +31,7 @@ import { useRoamReadyStore } from '@/shared/store';
  *
  */
 export const useSigninMutation = () => {
-  const router = useRouter();
+  // const router = useRouter();
   const setUser = useRoamReadyStore((state) => state.setUser);
   const queryClient = useQueryClient();
   const { showError } = useToast();
@@ -42,7 +42,8 @@ export const useSigninMutation = () => {
       setUser(data.user);
       queryClient.invalidateQueries({ queryKey: ['user', 'me'] });
       // showSuccess('로그인 되었습니다. 환영합니다!');
-      router.push(ROUTES.ACTIVITIES.ROOT);
+      // router.push(ROUTES.ACTIVITIES.ROOT);
+      window.location.href = ROUTES.ACTIVITIES.ROOT;
     },
 
     onError: (error: Error) => {

--- a/src/domain/Auth/hooks/useSignupMutation.ts
+++ b/src/domain/Auth/hooks/useSignupMutation.ts
@@ -62,7 +62,8 @@ export const useSignupMutation = (
       setUser(data);
       queryClient.invalidateQueries({ queryKey: ['user', 'me'] });
       showSuccess('회원가입이 완료되었습니다! 환영합니다.');
-      router.push(ROUTES.ACTIVITIES.ROOT);
+      // router.push(ROUTES.ACTIVITIES.ROOT);
+      window.location.href = ROUTES.ACTIVITIES.ROOT;
     },
 
     onError: (error: Error) => {

--- a/src/domain/Auth/schemas/request.ts
+++ b/src/domain/Auth/schemas/request.ts
@@ -21,7 +21,7 @@ const baseSignupRequestSchema = z.object({
     .min(8, { message: '비밀번호는 최소 8자 이상이어야 합니다.' }),
   passwordConfirm: z
     .string()
-    .min(8, { message: '비밀번호 확인을 입력해주세요.' }),
+    .min(8, { message: '비밀번호는 최소 8자 이상이어야 합니다.' }),
 });
 
 /**

--- a/src/domain/Auth/schemas/request.ts
+++ b/src/domain/Auth/schemas/request.ts
@@ -18,7 +18,13 @@ const baseSignupRequestSchema = z.object({
     .max(10, { message: '닉네임은 10자 이하로 입력해주세요.' }),
   password: z
     .string()
-    .min(8, { message: '비밀번호는 최소 8자 이상이어야 합니다.' }),
+    .min(8, { message: '비밀번호는 최소 8자 이상이어야 합니다.' })
+    .regex(
+      /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()_\-+=])[A-Za-z\d!@#$%^&*()_\-+=]+$/,
+      {
+        message: '비밀번호는 영문, 숫자, 특수문자를 모두 포함해야 합니다.',
+      },
+    ),
   passwordConfirm: z
     .string()
     .min(8, { message: '비밀번호는 최소 8자 이상이어야 합니다.' }),

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -47,7 +47,7 @@ export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const accessToken = request.cookies.get('accessToken')?.value;
 
-  if (!pathname.startsWith('/api/')) {
+  if (!pathname.startsWith(`${BRIDGE_API.PREFIX}/`)) {
     const isProtectedRoute = protectedPageRoutes.some((route) =>
       pathname.startsWith(route),
     );
@@ -66,7 +66,7 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  if (pathname.startsWith('/api/test/')) {
+  if (pathname.startsWith(`${BRIDGE_API.TEST_PREFIX}/`)) {
     return NextResponse.next();
   }
 

--- a/src/shared/components/ui/error-fallback/index.tsx
+++ b/src/shared/components/ui/error-fallback/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import LogoTextTwoline from '@/shared/assets/logos/LogoTextTwoline';
+import { CircleAlert } from 'lucide-react';
 
 /**
  * @description
@@ -11,9 +11,9 @@ import LogoTextTwoline from '@/shared/assets/logos/LogoTextTwoline';
  */
 const ErrorFallback = () => {
   return (
-    <div className='flex-col-center w-full gap-8 rounded-lg border border-red-300 bg-red-50 text-center text-gray-600'>
-      <div className='flex-center gap-14'>
-        <LogoTextTwoline className='font-size-15 size-100 text-red-700' />
+    <div className='flex-col-center w-full gap-8 rounded-lg border border-red-300 bg-red-50 p-8 text-center text-gray-600'>
+      <div className='flex-center gap-10'>
+        <CircleAlert className='font-size-15 size-30 text-red-700' />
         <h2 className='font-size-20 font-bold'>
           예상치 못한 문제가 발생했습니다.
         </h2>

--- a/src/shared/components/ui/toast/Toast.tsx
+++ b/src/shared/components/ui/toast/Toast.tsx
@@ -105,7 +105,7 @@ export default function Toast({
         'py-15 pr-9 pl-6',
         'max-w-400 min-w-300',
         'transform transition-all duration-500 ease-in-out',
-        isVisible ? 'translate-x-0' : 'translate-x-[calc(100%+30px)]',
+        isVisible ? 'translate-y-0' : '-translate-y-[calc(100%+30px)]',
         'border-l-8',
         currentTypeStyle.border,
       )}

--- a/src/shared/components/ui/toast/ToastContainer.tsx
+++ b/src/shared/components/ui/toast/ToastContainer.tsx
@@ -29,7 +29,7 @@ export default function ToastContainer() {
   }
 
   return createPortal(
-    <div className='fixed top-110 right-10 z-[1000] flex flex-col items-end gap-3'>
+    <div className='flex-col-center fixed top-15 left-1/2 z-[1000] -translate-x-1/2 gap-3'>
       {toasts.map((toast) => (
         <Toast key={toast.id} toast={toast} />
       ))}

--- a/src/shared/constants/bridgeEndpoints.ts
+++ b/src/shared/constants/bridgeEndpoints.ts
@@ -19,6 +19,7 @@
 export const BRIDGE_API = {
   PREFIX: '/api',
   AUTH_PREFIX: '/api/auth',
+  TEST_PREFIX: '/api/test',
 
   AUTH: {
     SIGNUP: 'signup',

--- a/src/shared/slices/toastSlice.ts
+++ b/src/shared/slices/toastSlice.ts
@@ -68,7 +68,7 @@ export const createToastSlice: StateCreator<ToastSlice, [], [], ToastSlice> = (
   get,
 ) => ({
   toasts: [],
-  addToast: ({ message, type = 'info', duration = 3000 }) => {
+  addToast: ({ message, type = 'info', duration = 2000 }) => {
     const id = crypto.randomUUID();
     const newToast: ToastState = { id, message, type, duration };
     set((state) => ({


### PR DESCRIPTION
## 👻 관련 이슈 번호

<!-- 관련 이슈 번호가 있으면 #번호 적어주세요. -->

- #448

## 👻 요약

<!-- 구현 및 수정한 내용을 간단하게 적어주세요. -->

- OAuth CSRF 방지를 위한 state 파라미터 랜덤 값 추가
- 로그인/회원가입 후 헤더 깜빡임 및 사용자 정보 미반영 문제 해결
- 로그인/회원가입 폼 UX 개선 (입력값 자동 유지)
- 비밀번호 및 닉네임 입력 유효성 강화
- ComponentErrorBoundary 디자인 개선

## 👻 주요 변경 사항

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요. -->

#### 인증 관련 개선
- 카카오 OAuth 요청에 랜덤 state 값 적용
→ CSRF 공격 방지를 위해 카카오 인증 요청 시 state 파라미터를 랜덤 문자열로 설정

- 로그인/회원가입 후 사용자 정보 반영 문제 해결
→ 기존 router.push 대신 window.location.href 사용
→ 서버에서 페이지를 새로 렌더링하도록 유도하여 AppLayout과 Header에서 사용자 정보가 즉시 반영되도록 처리
→ Tanstack Query만으로는 해결되지 않던 깜빡임 현상(GuestMenu → AuthMenu 전환) 제거

#### 폼 UX 개선
- 비밀번호 확인 필드 유효성 메시지 변경
→ 8자 미만일 경우 “비밀번호는 최소 8자 이상이어야 합니다”라는 메시지로 명확히 안내

- 비밀번호 유효성 검사 정교화
→ 영문 + 숫자 + 특수문자 포함 조건 추가

- 닉네임 입력 필드 제한 추가
→ maxLength=11으로 UI 입력 차단 + Zod 유효성 검사 병행 (11로 해야 메시지도 나옴)

- 입력값 자동 유지 기능 추가
  - 로그인 폼: 최근 로그인한 이메일을 persist로 자동 입력
  - 회원가입 폼: 입력 중 뒤로가기나 새로고침 시에도 값 유지 (sessionStorage)
→ 로그인 완료 or 회원가입 완료 시 sessionStorage 초기화

#### 기타
- ComponentErrorBoundary fallback 디자인 개선
→ fallback 조건 truthy 체크 → 명시적 존재 여부(!fallback)로 변경
- 토스트 위치 가운데로, 타이머 2초로 변경



## 👻 체크리스트

<!-- PR 올리기 전에 체크리스트를 꼭 확인해주세요. -->

- [x] Assignees에 본인을 등록했나요?
- [x] 라벨을 사이드 탭에서 등록했나요?
- [x] PR은 사이드 탭 Projects를 등록 **하지마세요.**
- [x] PR은 Milestone을 등록 **하지마세요.**
- [x] PR을 보내는 브랜치가 올바른지 확인했나요?
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했나요?
- [x] 변경사항을 충분히 테스트 했나요?
- [x] 컨벤션에 맞게 구현했나요?

## 📷 UI 변경 사항

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

<img width="600" height="701" alt="image" src="https://github.com/user-attachments/assets/eec077a4-6845-471c-898c-18531f631857" />


## 👻 문제 사항

<!-- 문제가 발생했다면 자세히 적어주세요.  -->

-

## 👻 논의 사항

<!-- 논의하고 싶은 사항을 적어 주시고, 토론이 필요하시면 토론 탭에 추가 부탁드립니다. -->

-

## 👻 기타 참고 사항

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주세요. -->

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 카카오 OAuth 인증의 state 파라미터에 고유 토큰을 추가하여 보안 강화.
  * 최근 로그인 이메일 자동 입력 기능 추가.
  * 회원가입 폼의 이메일/닉네임 임시 저장 및 자동 복원 기능 추가.
  * 테스트용 API 라우트 프리픽스 상수 추가.

* **버그 수정**
  * 카카오 OAuth 콜백에서 state 파라미터 검증 및 intent 파싱 강화.
  * 회원가입 시 닉네임 생성 규칙 변경.

* **개선 및 변경**
  * 비밀번호 유효성 검사 강화(영문, 숫자, 특수문자 포함 필수).
  * 회원가입 후, 로그인 후 페이지 이동 시 window.location.href 방식으로 변경(전체 새로고침).
  * 토스트 알림 기본 노출 시간 2초로 단축.
  * 토스트 위치를 상단 중앙으로 변경 및 애니메이션을 수직 슬라이드로 변경.
  * 에러 fallback UI에 경고 아이콘 적용.
  * 불필요한 주석 및 레거시 코드 정리.

* **문서화**
  * 여러 API 라우트 및 컴포넌트에 JSDoc 주석 개선 및 보강.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->