### PR TITLE
Fix: 예약 거절 시 캐시 무효화

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -13,6 +13,6 @@ const config: StorybookConfig = {
     name: '@storybook/nextjs-vite',
     options: {},
   },
-  staticDirs: ['..\\public'],
+  // staticDirs: ['..\\public'],
 };
 export default config;

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -13,6 +13,14 @@ const config: StorybookConfig = {
     name: '@storybook/nextjs-vite',
     options: {},
   },
-  // staticDirs: ['..\\public'],
+  staticDirs: ['../public'], // ← 경로 구분자 슬래시(`/`)로!
+  async viteFinal(config, { configType }) {
+    // Production build 시 base 경로 설정
+    if (configType === 'PRODUCTION') {
+      config.base = '/storybook/';
+    }
+    return config;
+  },
 };
+
 export default config;

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -13,9 +13,8 @@ const config: StorybookConfig = {
     name: '@storybook/nextjs-vite',
     options: {},
   },
-  staticDirs: ['../public'], // ← 경로 구분자 슬래시(`/`)로!
+  staticDirs: ['../public'],
   async viteFinal(config, { configType }) {
-    // Production build 시 base 경로 설정
     if (configType === 'PRODUCTION') {
       config.base = '/storybook/';
     }

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -13,7 +13,7 @@ const config: StorybookConfig = {
     name: '@storybook/nextjs-vite',
     options: {},
   },
-  staticDirs: ['../public'],
+  // staticDirs: ['../public'],
   async viteFinal(config, { configType }) {
     if (configType === 'PRODUCTION') {
       config.base = '/storybook/';

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build && storybook build -o public/storybook",
+    "build": "next build && storybook build -o public/storybook --base-url /storybook",
     "start": "next start",
     "lint": "next lint",
     "type-check": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build && storybook build -o public/storybook --base-url /storybook",
+    "build": "next build && storybook build -o public/storybook",
     "start": "next start",
     "lint": "next lint",
     "type-check": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build",
+    "build": "next build && storybook build -o .next/static/storybook",
     "start": "next start",
     "lint": "next lint",
     "type-check": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build && storybook build -o .next/static/storybook",
+    "build": "next build && storybook build -o public/storybook",
     "start": "next start",
     "lint": "next lint",
     "type-check": "tsc --noEmit",

--- a/src/app/storybook/page.tsx
+++ b/src/app/storybook/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+export default function StorybookRedirect() {
+  const router = useRouter();
+  useEffect(() => {
+    router.replace('/storybook/index.html');
+  }, []);
+  return null;
+}

--- a/src/domain/Activity/components/detail/activity-summary/ActivityDropdown.tsx
+++ b/src/domain/Activity/components/detail/activity-summary/ActivityDropdown.tsx
@@ -57,6 +57,7 @@ export default function ActivityDropdown({
     try {
       await deleteActivity(id);
       queryClient.invalidateQueries({ queryKey: activitiesKeys.all });
+      queryClient.invalidateQueries({ queryKey: ['carousel-activities'] });
       router.push('/activities');
     } catch (e) {
       console.error(e);

--- a/src/domain/Reservation/components/my-activity-card/DeleteMyActivityModal.tsx
+++ b/src/domain/Reservation/components/my-activity-card/DeleteMyActivityModal.tsx
@@ -29,6 +29,7 @@ export default function DeleteMyActivityModal({
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['my-activities'] });
+      queryClient.invalidateQueries({ queryKey: ['carousel-activities'] });
     },
   });
 

--- a/src/domain/Reservation/components/reservation-calendar/DayCell.tsx
+++ b/src/domain/Reservation/components/reservation-calendar/DayCell.tsx
@@ -205,7 +205,13 @@ export default function DayCell({
         status: 'declined',
       }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['reservationsBySchedule'] });
+      queryClient.invalidateQueries({
+        queryKey: [
+          'allReservationsByDate',
+          selectedActivityId,
+          day.format('YYYY-MM-DD'),
+        ],
+      });
       queryClient.invalidateQueries({ queryKey: ['schedules'] });
       queryClient.invalidateQueries({ queryKey: ['reservationDashboard'] });
     },

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/storybook",
+      "destination": "/_next/static/storybook/index.html"
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,0 @@
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "npm run build-storybook",
-  "outputDirectory": "storybook-static"
-}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "npm run build-storybook",
+  "outputDirectory": "storybook-static"
+}


### PR DESCRIPTION
## 👻 관련 이슈 번호

<!-- 관련 이슈 번호가 있으면 #번호 적어주세요. -->

- #510

## 👻 요약

<!-- 구현 및 수정한 내용을 간단하게 적어주세요. -->

- 예약 거절 시 캐시가 무효화 되도록 설정하였습니다.

## 👻 주요 변경 사항

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요. -->

- 캐시 무효화
- 스토리북 배포 테스트

## 👻 체크리스트

<!-- PR 올리기 전에 체크리스트를 꼭 확인해주세요. -->

- [ ] Assignees에 본인을 등록했나요?
- [ ] 라벨을 사이드 탭에서 등록했나요?
- [ ] PR은 사이드 탭 Projects를 등록 **하지마세요.**
- [ ] PR은 Milestone을 등록 **하지마세요.**
- [ ] PR을 보내는 브랜치가 올바른지 확인했나요?
- [ ] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했나요?
- [ ] 변경사항을 충분히 테스트 했나요?
- [ ] 컨벤션에 맞게 구현했나요?

## 📷 UI 변경 사항

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

-

## 👻 문제 사항

<!-- 문제가 발생했다면 자세히 적어주세요.  -->

-

## 👻 논의 사항

<!-- 논의하고 싶은 사항을 적어 주시고, 토론이 필요하시면 토론 탭에 추가 부탁드립니다. -->

-

## 👻 기타 참고 사항

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주세요. -->

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 빌드 스크립트가 업데이트되어, Next.js 빌드 후 Storybook 정적 파일이 `public/storybook` 디렉토리에 생성됩니다.
  * Storybook 설정에서 정적 파일 서빙이 비활성화되었습니다.
  * `/storybook` 경로를 통해 Storybook UI에 접근할 수 있도록 설정이 추가되었습니다.
  * Storybook 프로덕션 빌드 시 경로(base)가 `/storybook/`로 설정됩니다.
  * Storybook 접속 시 자동으로 `/storybook/index.html`로 리다이렉트되는 기능이 추가되었습니다.

* **버그 수정**
  * 예약 거절 시 예약 데이터 새로고침 범위가 개선되어, 더 정확한 정보가 반영됩니다.
  * 활동 삭제 후 캐러셀 활동 데이터도 함께 새로고침되어 최신 상태가 유지됩니다.
  * 내 활동 삭제 후 캐러셀 활동 및 내 활동 데이터가 모두 새로고침됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->