### PR TITLE
Fix: 로그인 시 헤더 즉각 업데이트

### DIFF
--- a/src/domain/Auth/hooks/useSigninMutation.ts
+++ b/src/domain/Auth/hooks/useSigninMutation.ts
@@ -2,10 +2,11 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { HTTPError } from 'ky';
 import { useRouter } from 'next/navigation';
 
+import { SigninResponse } from '@/domain/Auth/schemas/response';
 import { signin } from '@/domain/Auth/services';
 import { ROUTES } from '@/shared/constants/routes';
 import { useToast } from '@/shared/hooks/useToast';
-// import { useRoamReadyStore } from '@/shared/store';
+import { useRoamReadyStore } from '@/shared/store';
 
 /**
  * @function useSigninMutation
@@ -32,16 +33,15 @@ import { useToast } from '@/shared/hooks/useToast';
  */
 export const useSigninMutation = () => {
   const router = useRouter();
-  // const setUser = useRoamReadyStore((state) => state.setUser);
+  const setUser = useRoamReadyStore((state) => state.setUser);
   const queryClient = useQueryClient();
   const { showError } = useToast();
 
   return useMutation({
     mutationFn: signin,
-    onSuccess: () => {
-      // onSuccess: (data: SigninResponse) => {
+    onSuccess: (data: SigninResponse) => {
       sessionStorage.removeItem('signup-form');
-      // setUser(data.user);
+      setUser(data.user);
       queryClient.invalidateQueries({ queryKey: ['user', 'me'] });
       // showSuccess('로그인 되었습니다. 환영합니다!');
       router.push(ROUTES.ACTIVITIES.ROOT);


### PR DESCRIPTION
## 👻 관련 이슈 번호

<!-- 관련 이슈 번호가 있으면 #번호 적어주세요. -->

- none

## 👻 요약

<!-- 구현 및 수정한 내용을 간단하게 적어주세요. -->

- 로그인했을때 헤더가 로그인 헤더로 즉각 업데이트 되도록 수정 

## 👻 주요 변경 사항

<!-- 해당 PR의 변경 사항을 자세하게 적어주세요. -->

-

## 👻 체크리스트

<!-- PR 올리기 전에 체크리스트를 꼭 확인해주세요. -->

- [x] Assignees에 본인을 등록했나요?
- [x] 라벨을 사이드 탭에서 등록했나요?
- [x] PR은 사이드 탭 Projects를 등록 **하지마세요.**
- [x] PR은 Milestone을 등록 **하지마세요.**
- [x] PR을 보내는 브랜치가 올바른지 확인했나요?
- [x] 팀원들이 리뷰하기 쉽도록 설명을 자세하게 작성했나요?
- [x] 변경사항을 충분히 테스트 했나요?
- [x] 컨벤션에 맞게 구현했나요?

## 📷 UI 변경 사항

<!-- UI 관련 구현 및 수정 사항이 있다면 이미지 or 동영상을 첨부해주세요.  -->

-

## 👻 문제 사항

<!-- 문제가 발생했다면 자세히 적어주세요.  -->

-

## 👻 논의 사항

<!-- 논의하고 싶은 사항을 적어 주시고, 토론이 필요하시면 토론 탭에 추가 부탁드립니다. -->

-

## 👻 기타 참고 사항

<!-- 리뷰어가 확인해주면 좋은 부분이나 기타 등등을 작성해주세요. -->

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 로그인 성공 후 사용자 정보가 즉시 반영되지 않던 문제를 수정했습니다.
  - 로그인 후 캐시 갱신과 페이지 이동이 간헐적으로 실패하던 현상을 개선했습니다.
- 리팩터링
  - 로그인 성공 응답을 기반으로 전역 사용자 상태를 일관되게 갱신하도록 흐름을 정비하여, 로그인 이후 경험의 안정성과 예측 가능성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->